### PR TITLE
[Crash] NPE when calling stopScanning

### DIFF
--- a/device/src/main/java/com/aconno/sensorics/device/bluetooth/BluetoothImpl.kt
+++ b/device/src/main/java/com/aconno/sensorics/device/bluetooth/BluetoothImpl.kt
@@ -194,8 +194,10 @@ class BluetoothImpl(
 
     override fun stopScanning() {
         val bluetoothLeScanner = bluetoothAdapter.bluetoothLeScanner
-        scanEvent.onNext(ScanEvent.stop())
-        bluetoothLeScanner.stopScan(scanCallback)
+        bluetoothLeScanner?.let {
+            scanEvent.onNext(ScanEvent.stop())
+            it.stopScan(scanCallback)
+        }
     }
 
     override fun getGattResults(): Flowable<GattCallbackPayload> {


### PR DESCRIPTION
## Description
There is a crash happening stopping scanning.

### Crash details:
[BluetoothImpl.java](https://www.fabric.io/aconno-gmbh2/android/apps/com.aconno.sensorics/issues/5ca32d8bf8b88c296303b198?time=last-seven-days)
```
BluetoothImpl.java
com.aconno.sensorics.device.bluetooth.BluetoothImpl.stopScanning
```

## Issues to solve
* Performs stop scanning if the `BluetoothLeScanner` reference is not null.
