### PR TITLE
Timber logs should only be available in the "dev" build flavor

### DIFF
--- a/app/src/main/java/com/aconno/sensorics/SensoricsApplication.kt
+++ b/app/src/main/java/com/aconno/sensorics/SensoricsApplication.kt
@@ -16,6 +16,10 @@ import javax.inject.Inject
 
 class SensoricsApplication : Application(), HasActivityInjector, HasServiceInjector {
 
+    companion object {
+        private const val DEV_BUILD_FLAVOR = "dev"
+    }
+
     @Inject
     lateinit var dispatchingActivityInjector: DispatchingAndroidInjector<Activity>
 
@@ -32,7 +36,10 @@ class SensoricsApplication : Application(), HasActivityInjector, HasServiceInjec
             return
         }
         LeakCanary.install(this)
-        Timber.plant(Timber.DebugTree())
+        @Suppress("ConstantConditionIf")
+        if(BuildConfig.FLAVOR == DEV_BUILD_FLAVOR) {
+            Timber.plant(Timber.DebugTree())
+        }
         Fabric.with(this, Crashlytics())
     }
 


### PR DESCRIPTION
**Description**
Logs were available to the users even if the app is in the release flavor.

**Issues to solve**
* Changed planting the `Timber.DebugTree` to only when the build flavor is `"dev"`
