### PR TITLE
Removed suffix from .config files

### DIFF
--- a/app/src/main/assets/resources/configs/0401.config
+++ b/app/src/main/assets/resources/configs/0401.config
@@ -1,6 +1,6 @@
 {
 	"id" : "0401",
-	"name" : "acnACT_Old",
+	"name" : "acnACT",
 	"usecase_screen_path" : "/sensorics/usecase_screens/acnact.html",
 	"icon_path" : "/sensorics/icons/ic_act.png",
 	"format_path" : "/sensorics/formats/0401.json",

--- a/app/src/main/assets/resources/configs/BABA.config
+++ b/app/src/main/assets/resources/configs/BABA.config
@@ -1,6 +1,6 @@
 {
 	"id" : "BABA",
-	"name" : "acnRANGE_Old",
+	"name" : "acnRANGE",
 	"usecase_screen_path" : "/sensorics/usecase_screens/acnrange.html",
 	"icon_path" : "/sensorics/icons/ic_range.png",
 	"format_path" : "/sensorics/formats/BABA.json",

--- a/app/src/main/assets/resources/configs/CF00.config
+++ b/app/src/main/assets/resources/configs/CF00.config
@@ -1,6 +1,6 @@
 {
 	"id" : "CF00",
-	"name" : "acnSENSA_Old",
+	"name" : "acnSENSA",
 	"usecase_screen_path" : "/sensorics/usecase_screens/acnsensa.html",
 	"icon_path" : "/sensorics/icons/ic_sensa.png",
 	"format_path" : "/sensorics/formats/CF00.json",

--- a/app/src/main/assets/resources/configs/CF01.config
+++ b/app/src/main/assets/resources/configs/CF01.config
@@ -1,6 +1,6 @@
 {
 	"id" : "CF01",
-	"name" : "acnSENSA_Old",
+	"name" : "acnSENSA",
 	"usecase_screen_path" : "/sensorics/usecase_screens/acnsensa.html",
 	"icon_path" : "/sensorics/icons/ic_sensa.png",
 	"format_path" : "/sensorics/formats/CF00.json",

--- a/app/src/main/assets/resources/formats/0401.json
+++ b/app/src/main/assets/resources/formats/0401.json
@@ -1,6 +1,6 @@
 {
   "id": "0401",
-  "name": "acnACT_Old",
+  "name": "acnACT",
   "icon": "ic_act",
   "format": [
     {

--- a/app/src/main/assets/resources/formats/BABA.json
+++ b/app/src/main/assets/resources/formats/BABA.json
@@ -1,6 +1,6 @@
 {
   "id": "BABA",
-  "name": "acnRANGE_Old",
+  "name": "acnRANGE",
   "icon": "ic_acnrange",
   "format": [
     {

--- a/app/src/main/assets/resources/formats/CF00.json
+++ b/app/src/main/assets/resources/formats/CF00.json
@@ -1,6 +1,6 @@
 {
   "id": "CF00",
-  "name": "acnSENSA_Old",
+  "name": "acnSENSA",
   "icon": "ic_sensa",
   "format": [
     {

--- a/app/src/main/assets/resources/formats/CF01.json
+++ b/app/src/main/assets/resources/formats/CF01.json
@@ -1,6 +1,6 @@
 {
   "id": "CF01",
-  "name": "acnSENSA_Old",
+  "name": "acnSENSA",
   "icon": "ic_sensa",
   "format": [
     {


### PR DESCRIPTION
**Description**
The app contained beacon `.config` files, in which some of the names of the devices were written with the suffix: *`_Old`*

**Issues to solve**
Removed suffix the suffix: *`_Old`* .config files
