### PR TITLE
Fix bluetooh module

### DIFF
--- a/bluetooth/src/main/java/com/aconno/bluetooth/beacon/Parameters.kt
+++ b/bluetooth/src/main/java/com/aconno/bluetooth/beacon/Parameters.kt
@@ -77,5 +77,5 @@ class Parameters(
     inline fun <reified T> getParameterValue(name: String, default: T): T = map
             .flatMap { it.value }
             .find { it.name == name }
-            ?.value as T ?: (default)
+        ?.value as T? ?: (default)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ task clean(type: Delete) {
 }
 
 ext {
-    sensorics_version_code = 29
-    sensorics_version_name = '5.2.2'
+    sensorics_version_code = 30
+    sensorics_version_name = '5.2.3'
 
     compile_sdk_version = 28
     min_sdk_version = 21


### PR DESCRIPTION
**Description**
When firmware does not have a parameter that the library requires, the library makes the application disconnect from the connected device.

**Solution**
Make the reified function nullable.

