### PR TITLE
Fix multiple action issue

### DIFF
--- a/domain/src/main/java/com/aconno/sensorics/domain/format/FormatMatcher.kt
+++ b/domain/src/main/java/com/aconno/sensorics/domain/format/FormatMatcher.kt
@@ -91,6 +91,6 @@ class FormatMatcher(
             .forEach {
                 readingTypes.addAll(it.getFormat().keys)
             }
-        return readingTypes.sorted()
+        return readingTypes.distinct().sorted()
     }
 }


### PR DESCRIPTION
**Description**
This bug occured because of multiple deserializers existing for the same values for the same device because there are multiple advertisement formats that sometimes advertise the same values. Therefore we just need to eliminate the duplicates using .distinct()

**Issues to solve**
Issue # 186
