### PR TITLE
Ensuring that there is single instance of MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".ui.MainActivity"
-            android:launchMode="singleInstance" />
+            android:launchMode="singleTask" />
         <activity android:name=".ui.ActionListActivity" />
 
         <service
@@ -110,7 +110,7 @@
             android:name=".device.notification.AlarmNotificationReceiver"
             android:enabled="true">
             <intent-filter>
-                <action  android:name="com.troido.intent.action.ACTION_ALARM_SNOOZE" />
+                <action android:name="com.troido.intent.action.ACTION_ALARM_SNOOZE" />
             </intent-filter>
         </receiver>
 
@@ -123,8 +123,8 @@
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.aconno.sensorics.fileprovider"
-            android:grantUriPermissions="true"
-            android:exported="false">
+            android:exported="false"
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,9 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".ui.MainActivity" />
+        <activity
+            android:name=".ui.MainActivity"
+            android:launchMode="singleInstance" />
         <activity android:name=".ui.ActionListActivity" />
 
         <service


### PR DESCRIPTION
**Description**
Added option to MainActivity block in manifest to prevent the app from creating multiple instances of MainActivity.
**Issues to solve**
#229 
