### PR TITLE
remove robolectric android test dependency

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$test_runner_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"
     androidTestImplementation "org.mockito:mockito-inline:$mockito_inline_version"
-    androidTestImplementation "org.robolectric:robolectric:$robolectric_version"
 
     implementation ("com.microsoft.azure.sdk.iot:iot-device-client:$azure_iot_device_client_version"){
         exclude module: 'azure-storage'


### PR DESCRIPTION
**Description**
The android tests for module data were not starting because of a dependency issue. The test issue was fixed by removing the unused robolectric dependency from android test.